### PR TITLE
Add vendor code splitting

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -7,6 +7,8 @@
         <title>READY</title>
         <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
         <script src="{{ mix('/js/app.js') }}" defer></script>
+        <script src="{{ mix('/js/manifest.js') }}" defer></script>
+        <script src="{{ mix('/js/vendor.js') }}" defer></script>
         @inertiaHead
     </head>
     <body>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -12,6 +12,7 @@ const mix = require('laravel-mix');
  */
 
 mix.ts('resources/js/app.ts', 'public/js')
+    .extract()
     .vue()
     .sass('resources/sass/app.scss', 'public/css')
     .version();


### PR DESCRIPTION
Rather than just 1 large app.js this separates out the dependencies to a vendor.js. This can be beneficial if a JS change was made but no dependencies changed.