### PR TITLE
Temporarily Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
-version: 2
-updates:
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "*eslint*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+#version: 2
+#updates:
+#  - package-ecosystem: "composer"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
+#  - package-ecosystem: "npm"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
+#    ignore:
+#      - dependency-name: "*eslint*"
+#        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
We have no current production server so there isn't a huge need for dependency updates right now.